### PR TITLE
fixed Docker COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN mkdir -p /app/container_mount/checkpoints/
 RUN mkdir /app/robosat_container_files/
 
 # Copy our notebook and area of interest into docker
-COPY *.ipynb /app
-COPY osm/*.pbf /app/container_mount
-COPY images/* /app/images
+COPY *.ipynb /app/
+COPY osm/*.pbf /app/container_mount/
+COPY images/* /app/images/
 
 # Substitute required ENV variables 'DESIRED_ZOOM_LEVEL' and 'PUBLIC_IP'
 COPY entrypoint.sh /


### PR DESCRIPTION
Fixed Dockerfile COPY while source is multiple, or wildcard * files

Docker COPY reference: https://docs.docker.com/engine/reference/builder/#copy

> If multiple <src> resources are specified, either directly or due to the use of a wildcard, then <dest> must be a directory, and it must end with a slash /.

